### PR TITLE
Predefined cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Just run the `golife` command as follows
     golife
 ```
 
+To run a specific pattern, give the pattern name as the first argument, e.g.
+```
+    golife blinker
+```
+
 ## Development
 To run in Development mode:
 ```

--- a/exe/golife
+++ b/exe/golife
@@ -2,4 +2,4 @@
 
 require "golife"
 
-Golife::Game.new.play
+Golife::Game.new(ARGV.shift).play

--- a/lib/golife.rb
+++ b/lib/golife.rb
@@ -1,6 +1,7 @@
 # Conway's Game of Life Implementation in Ruby
 # Author: Vijay Soni(vs4vijay@gmail.com)
 require "golife/version"
+require "golife/playgrounds"
 
 SLEEP_INTERVAL = 0.2
 GAME_HEADING = "Game of Life"
@@ -8,11 +9,11 @@ GAME_HEADING = "Game of Life"
 class Golife::Game
   attr_accessor :playground, :width, :height, :generation
 
-  def initialize
+  def initialize(type = "random")
     self.generation = 0
     self.width = 10
     self.height = 10
-    self.playground = self.make_playground(self.height, self.width)
+    self.playground = Golife::Playgrounds.playground_for(type).build(height, width)
   end
 
   def play
@@ -21,19 +22,6 @@ class Golife::Game
       show_playground
       sleep SLEEP_INTERVAL
       next_generation
-    end
-  end
-
-  def make_playground(rows, cols, type = "random")
-    (1..rows).map do |i|
-      (1..cols).map do |j|
-      	if type == "empty"
-      	  cell_alive = false
-      	elsif type == "random"
-      	  cell_alive = Random.new.rand(0..1) == 1
-      	end
-      	Cell.new(i, j, cell_alive)
-      end
     end
   end
 

--- a/lib/golife/playgrounds.rb
+++ b/lib/golife/playgrounds.rb
@@ -1,3 +1,5 @@
+require "set"
+
 module Golife
   module Playgrounds
     def self.playground_for(type)
@@ -11,6 +13,39 @@ module Golife
         (1..rows).map do |i|
           (1..cols).map do |j|
             Cell.new(i, j, [true, false].sample)
+          end
+        end
+      end
+    end
+
+    module Blinker
+      def self.build(rows, cols)
+        blink_row = rows / 2
+
+        mid_col    = cols / 2
+        blink_cols = Set.new([mid_col - 1, mid_col, mid_col + 1])
+
+        (1..rows).map do |i|
+          (1..cols).map do |j|
+            Cell.new(i, j, i == blink_row && blink_cols.include?(j))
+          end
+        end
+      end
+    end
+
+    module Blocker
+      def self.build(rows, cols)
+        starting_blocks = Set.new([
+          [1, 7], [1, 9],
+          [2, 6],
+          [3, 1], [3, 2], [3, 5], [3, 10],
+          [4, 1], [4, 2], [4, 4], [4, 7], [4, 9], [4, 10],
+          [5, 5], [5, 6]
+        ])
+
+        (1..rows).map do |i|
+          (1..cols).map do |j|
+            Cell.new(i, j, starting_blocks.include?([i, j]))
           end
         end
       end

--- a/lib/golife/playgrounds.rb
+++ b/lib/golife/playgrounds.rb
@@ -1,0 +1,19 @@
+module Golife
+  module Playgrounds
+    def self.playground_for(type)
+      const_get(type.to_s.capitalize)
+    rescue NameError
+      Random
+    end
+
+    module Random
+      def self.build(rows, cols)
+        (1..rows).map do |i|
+          (1..cols).map do |j|
+            Cell.new(i, j, [true, false].sample)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/playgrounds_test.rb
+++ b/test/playgrounds_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class PlaygroundsTest < Minitest::Test
+  def test_playground_for_random_is_random
+    actual = Golife::Playgrounds.playground_for("random")
+
+    assert_equal Golife::Playgrounds::Random, actual
+  end
+
+  def test_playground_for_unknown_is_random
+    actual = Golife::Playgrounds::playground_for("unknown_pattern")
+
+    assert_equal Golife::Playgrounds::Random, actual
+  end
+end


### PR DESCRIPTION
A couple automatons for #4 

```
$ golife blinker
$ golife blocker
```

Here's a couple things that could be done here, or moved to new issues:
- what if the automaton can not be drawn in the playground? eg `Playgrounds::Blinker.build(1, 1)`

From the command line, if you ask for a specific automaton then the playground should be large enough to contain it, rather than the default of 10 x 10.
- if the pattern type is not defined, eg `golife undefined_type`, it falls back to a random pattern

It might be nicer if the printed playground included the pattern name so you know what you're looking at.
